### PR TITLE
feat(crd-operator): upgrade to 2026-06-16 release + expose vm-api via gateway

### DIFF
--- a/flux/apps/fluence/crd-operator/app/base/httproute.yml
+++ b/flux/apps/fluence/crd-operator/app/base/httproute.yml
@@ -19,3 +19,25 @@ spec:
         - path:
             type: PathPrefix
             value: /
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crd-operator-vm-console
+spec:
+  hostnames:
+    - vm-console.${NETWORK}-${PROVIDER}.cloudless.dev
+    - vm-console.${CLUSTER_ID}.${NETWORK}.cloudless.dev
+  parentRefs:
+    - name: eg-gw
+      namespace: ingress
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: crd-operator-vm-console
+          namespace: fluence
+          port: 8444
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/flux/apps/fluence/crd-operator/app/base/httproute.yml
+++ b/flux/apps/fluence/crd-operator/app/base/httproute.yml
@@ -34,7 +34,7 @@ spec:
       sectionName: https
   rules:
     - backendRefs:
-        - name: crd-operator-vm-console
+        - name: crd-operator-vm-api
           namespace: fluence
           port: 8444
       matches:

--- a/flux/apps/fluence/crd-operator/app/base/httproute.yml
+++ b/flux/apps/fluence/crd-operator/app/base/httproute.yml
@@ -23,11 +23,11 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: crd-operator-vm-console
+  name: crd-operator-vm-api
 spec:
   hostnames:
-    - vm-console.${NETWORK}-${PROVIDER}.cloudless.dev
-    - vm-console.${CLUSTER_ID}.${NETWORK}.cloudless.dev
+    - vm-api.${NETWORK}-${PROVIDER}.cloudless.dev
+    - vm-api.${CLUSTER_ID}.${NETWORK}.cloudless.dev
   parentRefs:
     - name: eg-gw
       namespace: ingress

--- a/flux/apps/fluence/crd-operator/app/base/httproute.yml
+++ b/flux/apps/fluence/crd-operator/app/base/httproute.yml
@@ -26,7 +26,6 @@ metadata:
   name: crd-operator-vm-api
 spec:
   hostnames:
-    - vm-api.${NETWORK}-${PROVIDER}.cloudless.dev
     - vm-api.${CLUSTER_ID}.${NETWORK}.cloudless.dev
   parentRefs:
     - name: eg-gw

--- a/flux/apps/fluence/crd-operator/app/base/release.yml
+++ b/flux/apps/fluence/crd-operator/app/base/release.yml
@@ -30,6 +30,8 @@ spec:
         size: 1Gi
 
     api:
+      console:
+        publicUrl: wss://vm-console.${NETWORK}-${PROVIDER}.cloudless.dev
       config:
         LTM__LOG_FORMAT: json
         LTM_CRD_API__STORAGE__NVME: "lvm-thin-r1"

--- a/flux/apps/fluence/crd-operator/app/base/release.yml
+++ b/flux/apps/fluence/crd-operator/app/base/release.yml
@@ -42,3 +42,8 @@ spec:
     vmApi:
       config:
         LTM__LOG_FORMAT: json
+      jwt:
+        # vodopad signs vm-access JWTs with `iss: "vodopad"`; vm-api validates
+        # `iss` against this exact string. Same in every env (the per-env
+        # bit lives in jwksUrl, which points at each env's vodopad JWKS).
+        issuer: "vodopad"

--- a/flux/apps/fluence/crd-operator/app/base/release.yml
+++ b/flux/apps/fluence/crd-operator/app/base/release.yml
@@ -38,3 +38,7 @@ spec:
     admission:
       config:
         LTM__LOG_FORMAT: json
+
+    vmApi:
+      config:
+        LTM__LOG_FORMAT: json

--- a/flux/apps/fluence/crd-operator/app/base/release.yml
+++ b/flux/apps/fluence/crd-operator/app/base/release.yml
@@ -30,8 +30,6 @@ spec:
         size: 1Gi
 
     api:
-      console:
-        publicUrl: wss://vm-console.${NETWORK}-${PROVIDER}.cloudless.dev
       config:
         LTM__LOG_FORMAT: json
         LTM_CRD_API__STORAGE__NVME: "lvm-thin-r1"

--- a/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
@@ -25,3 +25,8 @@ spec:
       image:
         repository: "docker.fluence.dev/crd-admission"
         tag: "0.3.4"
+
+    vmApi:
+      image:
+        repository: "docker.fluence.dev/crd-vm-api"
+        tag: "0.1.0"

--- a/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
@@ -30,3 +30,5 @@ spec:
       image:
         repository: "docker.fluence.dev/crd-vm-api"
         tag: "0.1.0"
+      jwt:
+        jwksUrl: "https://api.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
@@ -29,6 +29,6 @@ spec:
     vmApi:
       image:
         repository: "docker.fluence.dev/crd-vm-api"
-        tag: "0.1.0"
+        tag: "0.2.0"
       jwt:
         jwksUrl: "https://api.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
@@ -12,19 +12,19 @@ spec:
     controller:
       image:
         repository: "docker.fluence.dev/crd-controller"
-        tag: "0.6.8"
+        tag: "0.7.0"
       persistence:
         storageClassName: lvm-thin-r2
 
     api:
       image:
         repository: "docker.fluence.dev/crd-api"
-        tag: "0.8.6"
+        tag: "0.10.0"
 
     admission:
       image:
         repository: "docker.fluence.dev/crd-admission"
-        tag: "0.3.4"
+        tag: "0.4.1"
 
     vmApi:
       image:

--- a/flux/apps/fluence/crd-operator/app/overlays/mainnet/repository.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/mainnet/repository.yml
@@ -6,4 +6,4 @@ spec:
   interval: 5m0s
   url: oci://registry-1.docker.io/fluencelabs/crd-operator-chart
   ref:
-    tag: 0.0.8
+    tag: 0.0.9

--- a/flux/apps/fluence/crd-operator/app/overlays/mainnet/repository.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/mainnet/repository.yml
@@ -6,4 +6,4 @@ spec:
   interval: 5m0s
   url: oci://registry-1.docker.io/fluencelabs/crd-operator-chart
   ref:
-    tag: 0.0.9
+    tag: 0.1.0

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/httproute.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/httproute.yml
@@ -18,3 +18,24 @@ spec:
         - name: crd-operator-api
           port: 8080
           namespace: fluence
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: crd-operator-vm-console
+spec:
+  hostnames:
+    - vm-console.stage-cloudless.cloudless.dev
+  parentRefs:
+    - name: eg-gw
+      namespace: ingress
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: crd-operator-vm-console
+          port: 8444
+          namespace: fluence

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/httproute.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/httproute.yml
@@ -18,24 +18,3 @@ spec:
         - name: crd-operator-api
           port: 8080
           namespace: fluence
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: crd-operator-vm-console
-spec:
-  hostnames:
-    - vm-console.stage-cloudless.cloudless.dev
-  parentRefs:
-    - name: eg-gw
-      namespace: ingress
-      sectionName: https
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - name: crd-operator-vm-console
-          port: 8444
-          namespace: fluence

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
@@ -16,3 +16,6 @@ spec:
     controller:
       persistence:
         storageClassName: lvm-thin-r1
+    api:
+      console:
+        publicUrl: wss://vm-console.stage-cloudless.cloudless.dev

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
@@ -16,6 +16,3 @@ spec:
     controller:
       persistence:
         storageClassName: lvm-thin-r1
-    api:
-      console:
-        publicUrl: wss://vm-console.stage-cloudless.cloudless.dev

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
@@ -18,5 +18,8 @@ spec:
         storageClassName: lvm-thin-r1
 
     vmApi:
+      image:
+        repository: "docker.fluence.dev/crd-vm-api"
+        tag: "0.1.0"
       jwt:
         jwksUrl: "https://api.stage.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
@@ -16,3 +16,7 @@ spec:
     controller:
       persistence:
         storageClassName: lvm-thin-r1
+
+    vmApi:
+      jwt:
+        jwksUrl: "https://api.stage.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
@@ -20,6 +20,6 @@ spec:
     vmApi:
       image:
         repository: "docker.fluence.dev/crd-vm-api"
-        tag: "0.1.0"
+        tag: "0.2.0"
       jwt:
         jwksUrl: "https://api.stage.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
@@ -25,3 +25,8 @@ spec:
       image:
         repository: "docker.fluence.dev/crd-admission"
         tag: "0.3.4"
+
+    vmApi:
+      image:
+        repository: "docker.fluence.dev/crd-vm-api"
+        tag: "0.1.0"

--- a/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
@@ -30,3 +30,5 @@ spec:
       image:
         repository: "docker.fluence.dev/crd-vm-api"
         tag: "0.1.0"
+      jwt:
+        jwksUrl: "https://api.testnet.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
@@ -29,6 +29,6 @@ spec:
     vmApi:
       image:
         repository: "docker.fluence.dev/crd-vm-api"
-        tag: "0.1.0"
+        tag: "0.2.0"
       jwt:
         jwksUrl: "https://api.testnet.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
@@ -12,19 +12,19 @@ spec:
     controller:
       image:
         repository: "docker.fluence.dev/crd-controller"
-        tag: "0.6.8"
+        tag: "0.7.0"
       persistence:
         storageClassName: lvm-thin-r2
 
     api:
       image:
         repository: "docker.fluence.dev/crd-api"
-        tag: "0.8.6"
+        tag: "0.10.0"
 
     admission:
       image:
         repository: "docker.fluence.dev/crd-admission"
-        tag: "0.3.4"
+        tag: "0.4.1"
 
     vmApi:
       image:

--- a/flux/apps/fluence/crd-operator/app/overlays/testnet/repository.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/testnet/repository.yml
@@ -6,4 +6,4 @@ spec:
   interval: 5m0s
   url: oci://registry-1.docker.io/fluencelabs/crd-operator-chart
   ref:
-    tag: 0.0.8
+    tag: 0.0.9

--- a/flux/apps/fluence/crd-operator/app/overlays/testnet/repository.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/testnet/repository.yml
@@ -6,4 +6,4 @@ spec:
   interval: 5m0s
   url: oci://registry-1.docker.io/fluencelabs/crd-operator-chart
   ref:
-    tag: 0.0.9
+    tag: 0.1.0


### PR DESCRIPTION
Upgrades the fluence crd-operator overlays to the lightmare release published 2026-06-16, and adds the gateway plumbing for `crd-vm-api`, the new lightmare binary that owns the user-facing console-WS and userpassword endpoints.

### Version bumps (testnet + mainnet)
- chart `crd-operator-chart` `0.0.9` → `0.1.0`
- `crd-vm-api` `0.1.0` → `0.2.0` (also stage)
- `crd-controller` `0.6.8` → `0.7.0`
- `crd-api` `0.8.6` → `0.10.0`
- `crd-admission` `0.3.4` → `0.4.1`

### What the new versions bring
- **#603 — user password & serial console endpoints** (chart 0.1.0, api 0.10.0, controller 0.7.0): the feature this PR wires through the gateway.
- **#631 — hot-reload of TLS serving certs** (controller 0.7.0, admission 0.4.1): cert rotation without a pod restart.
- **#604 — VM nested-virt parameter** (controller 0.7.0).
- **#607 — redb IP cache extracted to `allocated-ip-cache` lib + `crd-db` CLI**, **#606 — IP cache cleanup on PublicIp delete regardless of status** (controller 0.7.0).
- **#572 — structured admission errors passed through to api & client** (api 0.10.0 via 0.9.0, admission 0.4.0): typed admission failures instead of opaque strings.

⚠️ **Breaking (chart 0.1.0 / #603):** `controller.aggregatedApi.enabled` is gone — the aggregated APIService + Certificate + Issuer + Service are always installed, so **cert-manager is now a hard prerequisite**. crd-vm-console's ClusterRole changed to grant `subresources.cloudless.dev/virtualmachines/consumeConsoleToken` create instead of cluster-wide `secrets get/list/delete`. These overlays don't pin `aggregatedApi` or a custom RBAC overlay, so chart defaults cover it — no flux-side change needed.

### Gateway
- HTTPRoute `crd-operator-vm-api` on `vm-api.${NETWORK}-${PROVIDER}.cloudless.dev` / `vm-api.${CLUSTER_ID}.${NETWORK}.cloudless.dev` → backend `crd-operator-vm-api:8444` (plain HTTP/WS).
- Base release sets `LTM__LOG_FORMAT=json` for vm-api, in line with the other crd-operator components.
- No SecurityPolicy — auth is RS256-JWT verified by vm-api itself against vodopad's JWKS (lightmare NKS #125), no gateway-side check needed.

Goes with fluencelabs/lightmare#603. Chart `0.1.0` and the component images are now published, so the earlier `Do not merge` blocker is lifted.