### PR TITLE
chore(crd-api): trust central authentik issuer (vodopad-${NETWORK})

### DIFF
--- a/flux/apps/fluence/crd-operator/app/base/securitypolicy.yml
+++ b/flux/apps/fluence/crd-operator/app/base/securitypolicy.yml
@@ -8,9 +8,9 @@ spec:
     optional: false
     providers:
       - name: authentik
-        issuer: https://authentik.${NETWORK}.cloudless.dev/application/o/jwks/
+        issuer: https://authentik.cloudless.dev/application/o/vodopad-${NETWORK}/
         remoteJWKS:
-          uri: https://authentik.${NETWORK}.cloudless.dev/application/o/jwks/jwks/
+          uri: https://authentik.cloudless.dev/application/o/vodopad-${NETWORK}/jwks/
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute


### PR DESCRIPTION
## What
Point the crd-operator-api JWT SecurityPolicy at the central IdP and the new per-env vodopad app slug:

```diff
- issuer: https://authentik.${NETWORK}.cloudless.dev/application/o/jwks/
- uri:    https://authentik.${NETWORK}.cloudless.dev/application/o/jwks/jwks/
+ issuer: https://authentik.cloudless.dev/application/o/vodopad-${NETWORK}/
+ uri:    https://authentik.cloudless.dev/application/o/vodopad-${NETWORK}/jwks/
```

## Why
crd-api rejects every vodopad call with `401 - Jwt issuer is not configured`. Its SecurityPolicy still trusts the **decommissioned per-env host** `authentik.${NETWORK}.cloudless.dev` (now NXDOMAIN) and the old `jwks` app slug. After the central-IdP consolidation, vodopad's envoy obtains tokens from `https://authentik.cloudless.dev/application/o/vodopad-<env>/` — so crd-api must trust that issuer/JWKS instead.

Verified against live OIDC discovery — issuer/jwks_uri match `vodopad-${NETWORK}` for all three envs:
- mainnet → `…/application/o/vodopad-mainnet/`
- stage → `…/application/o/vodopad-stage/`
- testnet → `…/application/o/vodopad-testnet/`

## Context
Final piece of the central-IdP migration for vodopad↔crd-api:
- fluence-config#108 — envoy → central host (merged)
- infra#262 — vodopad M2M clients on central IdP (merged)
- infra#263 — 24h token TTL (merged); surfaced the real error as `issuer not configured` rather than `expired`

Once this reconciles on each kabat cluster, crd-api should accept vodopad's tokens and reconciliation resumes.