### PR TITLE
feat(kubevirt): enable VolumesUpdateStrategy + VolumeMigration gates

### DIFF
--- a/flux/apps/kubevirt/kubevirt/app/kubevirt.yml
+++ b/flux/apps/kubevirt/kubevirt/app/kubevirt.yml
@@ -12,3 +12,10 @@ spec:
         - AlignCPUs
         - NUMA
         - ExpandDisks
+        # Enable storage live-migration: lets KubeVirt mirror disks onto a new
+        # PVC on a running VM (libvirt drive-mirror), so RWO→RWX conversion and
+        # storage-class moves don't need downtime. Requires VolumesUpdateStrategy
+        # set on the VM (`spec.updateVolumesStrategy: Migration`) plus a target
+        # PVC with the desired accessModes/storageClass.
+        - VolumesUpdateStrategy
+        - VolumeMigration


### PR DESCRIPTION
Turn on the `VolumesUpdateStrategy` and `VolumeMigration` alpha gates so that swapping a running VM's PVC triggers a libvirt drive-mirror instead of a reboot. No behaviour change for VMs that don't set `spec.updateVolumesStrategy: Migration`.

Right now RWO→RWX conversion and storage-class moves require stopping the VM. With these gates on, KubeVirt accepts a new `claimName` on a running VM and mirrors blocks onto the target PVC, then atomically pivots — no guest restart.

Caveats (not in this PR):
- Storage live-migration needs the target launcher pod on a different node (kubevirt uses hard anti-affinity on `kubernetes.io/hostname`). **stage** is single-node, so the gates will be visible but the migration itself can only be exercised on **testnet**.
- The target PVC must be a real shared volume. Existing `lvm-thin-r*` SCs have no `DrbdOptions/Net/allow-two-primaries`, so today's "RWX" PVCs are fake-RWX (only one attacher actually works). A separate SC with `allow-two-primaries=yes` is needed for real multi-host RWX.
- KubeVirt 1.4.1 has [kubevirt#15599](https://github.com/kubevirt/kubevirt/pull/15599): virt-controller's JSON-patch test on pod conditions fails against k8s 1.34 because `observedGeneration` is now on every PodCondition. Migrations create new launcher pods → hit the bug on first reconcile. Either backport the fix or accept the requeue noise.