### PR TITLE
fix(grafana): source mesh root CA for tls_client_ca from fluence-mesh-intermediate secret

### DIFF
--- a/flux/apps/observability/grafana/app/grafana.yml
+++ b/flux/apps/observability/grafana/app/grafana.yml
@@ -68,8 +68,8 @@ spec:
       #     2026-06-05 (getent + OIDC discovery 200; see PR #142).
       # authentik.infra's leaf is signed DIRECTLY by the Fluence Mesh Root (infra Issuer
       # fluence-root-ca; chain leaf->root, no intermediate — confirmed issuer=CN=Fluence Mesh Root CA).
-      # Grafana's server-side OAuth client must trust that root explicitly; mounted from the bootstrap
-      # ConfigMap fluence-mesh-root-ca (public cert only; see deployment volumes).
+      # Grafana's server-side OAuth client must trust that root explicitly; mounted from the ca.crt of
+      # the fluence-mesh-intermediate secret (= the public Fluence Mesh Root cert; see deployment volumes).
       auth_url: "https://authentik.infra/application/o/authorize/"
       token_url: "https://authentik.infra/application/o/token/"
       api_url: "https://authentik.infra/application/o/userinfo/"
@@ -182,12 +182,17 @@ spec:
             - name: grafana-data
               persistentVolumeClaim:
                 claimName: grafana-pvc
-            # Fluence Mesh Root (public CA cert only — no key) for tls_client_ca. Bootstrap ConfigMap,
-            # hand-delivered like the fluence-mesh-intermediate secret (the root key never leaves
-            # infrahub; the cert is public). Key `root.crt`.
+            # Fluence Mesh Root (public CA cert) for tls_client_ca — sourced from the ca.crt of the
+            # fluence-mesh-intermediate bootstrap secret (already required on every cluster; its ca.crt
+            # IS the self-signed CN=Fluence Mesh Root CA). Reusing it avoids a second hand-delivered
+            # object: a missing standalone configmap wedged the grafana pod in ContainerCreating
+            # (8h outage on stage 2026-06-05). Projected to root.crt to match tls_client_ca above.
             - name: fluence-ca
-              configMap:
-                name: fluence-mesh-root-ca
+              secret:
+                secretName: fluence-mesh-intermediate
+                items:
+                  - key: ca.crt
+                    path: root.crt
           securityContext:
             # Only fsGroup at pod level (RWO PVC group ownership). runAsUser/runAsGroup/runAsNonRoot
             # are set on the grafana CONTAINER instead, so the operator-injected netbird sidecar (which


### PR DESCRIPTION
## Problem

`grafana.yml` mounts the Fluence Mesh Root CA (used as the OIDC back-channel `tls_client_ca` to `authentik.infra`) from a standalone **bootstrap ConfigMap `fluence-mesh-root-ca`** that nothing in the repo creates — it had to be hand-delivered to every cluster.

On stage (2026-06-05) that ConfigMap went missing (removed while winding down an experiment) and the grafana pod was wedged in `ContainerCreating` for **8h**:

```
MountVolume.SetUp failed for volume "fluence-ca": configmap "fluence-mesh-root-ca" not found
```

→ `grafana-service` had no endpoints → `grafana.<cluster_id>.<network>.spectrum` stopped opening.

## Fix

Source the root from the **`ca.crt` of the `fluence-mesh-intermediate` secret** instead of a separate ConfigMap. That secret is already a required bootstrap on every cluster, and its `ca.crt` **is** the self-signed `CN=Fluence Mesh Root CA` (the same root that signs `authentik.infra`). It's projected to `root.crt`, so `/etc/fluence-ca/root.crt` is unchanged — byte-identical to the file that's currently working, just one fewer hand-delivered object.

```yaml
- name: fluence-ca
  secret:
    secretName: fluence-mesh-intermediate
    items:
      - key: ca.crt
        path: root.crt
```

## Notes

- Removes the `fluence-mesh-root-ca` ConfigMap dependency entirely → eliminates the "missing configmap wedges the pod in ContainerCreating" failure mode.
- Assumes the hand-delivered `fluence-mesh-intermediate` secret includes `ca.crt` (it does on stage — 3 keys).
- Once this deploys, the manually-created `fluence-mesh-root-ca` ConfigMap on stage becomes unused and can be deleted.
