### PR TITLE
feat(networking): deploy NetBird on testnet and mainnet so Grafana mesh OIDC works on all clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,25 @@ kubectl create secret generic alertmanager-config \
 
 ### Secret: `netbird-api-token` (namespace: `networking`)
 
-NetBird API token for the kubernetes-operator to connect to centralized management.
+Required on every cluster that deploys the `networking` (NetBird) app group — i.e.
+all clusters running the observability stack, since Grafana joins the mesh to reach
+the mesh-only authentik.infra for OIDC.
+
+A hand-seeded admin PAT for the per-cluster NetBird service user `spectrum-<NETWORK>`
+(e.g. `spectrum-testnet`). The service user, plus the shared `support` and `admins`
+groups, must already exist on the centralized management at
+`netbird.infrahub.cloudless.dev`. The `netbird-token-rotate` CronJob rotates this PAT
+in place afterwards.
+
+The secret key consumed by the operator and the setup/rotate jobs is `NB_API_KEY`
+(not `token`):
 
 ```bash
+kubectl create namespace networking
 kubectl create secret generic netbird-api-token \
   --namespace networking \
-  --from-literal=token=<YOUR_NETBIRD_API_TOKEN>
+  --from-literal=NB_API_KEY=<spectrum-NETWORK_admin_PAT>
 ```
+
+The `netbird-gate` Flux Kustomization health-gates the whole NetBird stack on this
+secret, so the rest of the cluster reconciles normally until it is present.

--- a/clusters/mainnet/kustomization.yml
+++ b/clusters/mainnet/kustomization.yml
@@ -10,4 +10,5 @@ resources:
   - ../../flux/apps/storage
   - ../../flux/apps/ingress
   - ../../flux/apps/observability
+  - ../../flux/apps/networking
   - ../../flux/apps/fluence

--- a/clusters/testnet/kustomization.yml
+++ b/clusters/testnet/kustomization.yml
@@ -10,4 +10,5 @@ resources:
   - ../../flux/apps/storage
   - ../../flux/apps/ingress
   - ../../flux/apps/observability
+  - ../../flux/apps/networking
   - ../../flux/apps/fluence

--- a/flux/apps/networking/netbird-operator-config/app/overlays/mainnet/kustomization.yml
+++ b/flux/apps/networking/netbird-operator-config/app/overlays/mainnet/kustomization.yml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+patches:
+  - path: release.yml

--- a/flux/apps/networking/netbird-operator-config/app/overlays/mainnet/release.yml
+++ b/flux/apps/networking/netbird-operator-config/app/overlays/mainnet/release.yml
@@ -1,0 +1,8 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: netbird-operator-config
+spec:
+  values:
+    router:
+      replicas: 1


### PR DESCRIPTION
## What

Deploy the `networking` (NetBird) app group on **testnet** and **mainnet**. Until now
only `stage` pulled in `flux/apps/networking`, so NetBird ran on a single cluster.

## Why — Grafana is already wired for the mesh everywhere

The observability stack (on `stage`, `testnet`, `mainnet`) already assumes NetBird:

- `observability/grafana/app/netbird-setupkey.yml` creates `SetupKey` /
  `NBSetupKey` CRs — whose CRDs are installed **only** by the `netbird-operator`
  HelmRelease.
- the Grafana pod carries `netbird.io/setup-key: grafana`, requiring the operator's
  mutating webhook to inject the mesh sidecar.
- `root_url: https://grafana.${CLUSTER_ID}.${NETWORK}.spectrum` and all three OIDC
  legs target the **mesh-only** `authentik.infra`.

On any cluster without the `networking` group those CRs reference missing CRDs and the
sidecar is never injected, so Grafana login is broken. Adding NetBird makes Grafana
work on every cluster that runs it.

## Changes

- `clusters/testnet/kustomization.yml` — add `../../flux/apps/networking`.
- `clusters/mainnet/kustomization.yml` — add `../../flux/apps/networking`.
- `netbird-operator-config/app/overlays/mainnet/` — add `release.yml` with
  `router.replicas: 1` (parity with `stage`/`testnet`; the router's `NBRoutingPeer`
  must run, otherwise `netbird-services-grafana` blocks waiting on its `networkID`).
- `README.md` — document the per-cluster `netbird-api-token` secret correctly: the
  consumed key is **`NB_API_KEY`** (the old example used `token`, which never worked),
  plus the `spectrum-<network>` service-user / `support`+`admins` group prerequisites.

`dev` is intentionally **not** included: it has no observability/Grafana, and
`netbird-services-grafana` `dependsOn: grafana`, so it would never reconcile there.
Only the `netbirdio` `HelmRepository` source is present on `dev` (via
`flux/repositories`), which is harmless.

## Per-cluster bootstrap requirement (out-of-band)

Each newly-onboarded cluster needs its NetBird operator PAT seeded once:

```bash
kubectl create namespace networking
kubectl create secret generic netbird-api-token -n networking \
  --from-literal=NB_API_KEY=<spectrum-NETWORK_admin_PAT>
```

`netbird-gate` health-gates the whole NetBird stack on this secret, so the rest of the
cluster reconciles normally until it is present — **safe to merge before seeding.**
The `netbird-token-rotate` CronJob rotates the PAT afterwards.

## Rollout

`stage` tracks `main` and picks this up on merge. `testnet`/`mainnet` are pinned to the
`testnet`/`mainnet` git tags, so they only deploy NetBird once those tags are advanced
to include this commit.

## Validation

`kubectl kustomize` is green for `clusters/testnet`, `clusters/mainnet` (68 objects
each) and for all three `netbird-operator-config` overlays; the mainnet overlay renders
`router.replicas: 1`.
