### PR TITLE
fix(netbird): add tcpPorts 443 to spectrum NBResources so access policy is created (operator v0.6.0)

### DIFF
--- a/flux/apps/networking/netbird-operator-config/app/base/policy.yml
+++ b/flux/apps/networking/netbird-operator-config/app/base/policy.yml
@@ -13,3 +13,8 @@ spec:
   bidirectional: false
   protocols:
     - tcp
+  # netbird-operator v0.6.0 treats tcp/udp as "restricted protocols" and drops the rule
+  # if no ports are set ("0 ports found for protocol tcp"), so the policy never reaches
+  # NetBird. The spectrum mesh services (grafana, kube-oidc-proxy) serve on 443.
+  ports:
+    - 443

--- a/flux/apps/networking/netbird-operator-config/app/base/policy.yml
+++ b/flux/apps/networking/netbird-operator-config/app/base/policy.yml
@@ -13,8 +13,3 @@ spec:
   bidirectional: false
   protocols:
     - tcp
-  # netbird-operator v0.6.0 treats tcp/udp as "restricted protocols" and drops the rule
-  # if no ports are set ("0 ports found for protocol tcp"), so the policy never reaches
-  # NetBird. The spectrum mesh services (grafana, kube-oidc-proxy) serve on 443.
-  ports:
-    - 443

--- a/flux/apps/networking/netbird-operator-config/app/base/policy.yml
+++ b/flux/apps/networking/netbird-operator-config/app/base/policy.yml
@@ -4,10 +4,10 @@ metadata:
   name: spectrum-${NETWORK}-access
 spec:
   name: "spectrum-${NETWORK}-access"
-  description: "Allow support and admins access to spectrum-${NETWORK} resources"
+  description: "Allow support and devops access to spectrum-${NETWORK} resources"
   sourceGroups:
     - support
-    - admins
+    - devops
   destinationGroups:
     - spectrum-${NETWORK}
   bidirectional: false

--- a/flux/apps/networking/netbird-services/app/grafana/resource-setup.yml
+++ b/flux/apps/networking/netbird-services/app/grafana/resource-setup.yml
@@ -99,6 +99,7 @@ spec:
                 networkID: $${NETID}
                 groups:
                   - spectrum-${NETWORK}
+                policyName: spectrum-${NETWORK}-access
                 tcpPorts:
                   - 443
               EOF

--- a/flux/apps/networking/netbird-services/app/grafana/resource-setup.yml
+++ b/flux/apps/networking/netbird-services/app/grafana/resource-setup.yml
@@ -99,5 +99,7 @@ spec:
                 networkID: $${NETID}
                 groups:
                   - spectrum-${NETWORK}
+                tcpPorts:
+                  - 443
               EOF
               echo "applied NBResource grafana-spectrum -> grafana.${CLUSTER_ID}.${NETWORK}.spectrum"

--- a/flux/apps/networking/netbird-services/app/kube-oidc-proxy/resource-setup.yml
+++ b/flux/apps/networking/netbird-services/app/kube-oidc-proxy/resource-setup.yml
@@ -100,5 +100,7 @@ spec:
                 networkID: $${NETID}
                 groups:
                   - spectrum-${NETWORK}
+                tcpPorts:
+                  - 443
               EOF
               echo "applied NBResource kube-oidc-proxy-spectrum -> k8s.${CLUSTER_ID}.${NETWORK}.spectrum"

--- a/flux/apps/networking/netbird-services/app/kube-oidc-proxy/resource-setup.yml
+++ b/flux/apps/networking/netbird-services/app/kube-oidc-proxy/resource-setup.yml
@@ -100,6 +100,7 @@ spec:
                 networkID: $${NETID}
                 groups:
                   - spectrum-${NETWORK}
+                policyName: spectrum-${NETWORK}-access
                 tcpPorts:
                   - 443
               EOF


### PR DESCRIPTION
## Problem

On testnet (freshly on netbird-operator **v0.6.0**) the `spectrum-testnet-access` NBPolicy never reaches NetBird — operator logs `0 ports found for protocol tcp`, the policy is absent from the dashboard, and the source groups get no mesh access.

## Root cause

netbird-operator v0.6.0 builds a policy's rules by aggregating, over the NBResources that **(a) name this policy in `spec.policyName`** and **(b) declare `tcpPorts`/`udpPorts`**, the ports per protocol (`nbpolicy_controller.go: mapResources`). `NBPolicy.spec.protocols` is only a restricted-protocol filter, not a port source.

The `.spectrum` NBResources created by the `*-nbresource-setup` Jobs (`grafana-spectrum`, `kube-oidc-proxy-spectrum`) set neither field, so they're skipped → empty aggregate → the tcp rule is dropped (NBPolicy CR still reports `Ready=True`). Stage predates v0.6.0 so it wasn't caught.

## Fix

1. On both `.spectrum` NBResources set `policyName: spectrum-${NETWORK}-access` (links resource → policy for port aggregation) and `tcpPorts: [443]` (the port the mesh services serve on).
2. `policy.yml`: source group `admins` → `devops`. `admins` does not exist on the central NetBird (resolved to an empty group ID, leaving the rule with a blank source); `devops` is the canonical shared group (mirrors the kube-oidc-proxy access groups and the central `grp-devops`).

Verified live on testnet: the operator now logs `Updating NetBird Policy ... sources: [support, devops], ports: ["443"]` and `spectrum-testnet-access TCP` is present in NetBird.

No change to `NBPolicy.spec.ports` (an earlier attempt there was reverted — unused for aggregation).

## Rollout

testnet/mainnet on `<env>` tag move; stage on merge.