### PR TITLE
fix(observability): bump node-exporter memory limit 64M → 256M (OOMKill on mainnet)

### DIFF
--- a/flux/apps/observability/node-exporter/app/release.yml
+++ b/flux/apps/observability/node-exporter/app/release.yml
@@ -37,6 +37,6 @@ spec:
         cpu: 23m
         memory: 64M
       limits:
-        memory: 64M
+        memory: 256M
 
     hostNetwork: false


### PR DESCRIPTION
## Problem

`node-exporter` is chronically **OOMKilled** (`exitCode 137`) on the **mainnet** spectrum cluster. Its memory `request` and `limit` are both pinned to `64M`, leaving zero burst headroom.

Observed on mainnet (nodes `fra-flix*`):

| pod | node | restarts | last reason |
|---|---|---|---|
| node-exporter-hl7jh | fra-flix3-03 | 237 | OOMKilled |
| node-exporter-fvgnz | fra-flix3-02 | 80 | OOMKilled |
| node-exporter-pwgxt | fra-flix2-01 | 38 | OOMKilled |

Each restart leaves a gap in node metrics.

## Root cause

node-exporter RSS scales with hardware (CPU count, mount points, netdevs, processes). The mainnet `fra-flix*` nodes are large enough to push it past `64M`. testnet (`kabat-02/03`) and stage (`kabat-05`) run the **same 64M limit** but currently sit at **0 restarts** because their single small nodes stay under the threshold — so they carry the same latent risk without tripping it yet.

## Fix

Raise `limits.memory` to `256M`, keep `requests.memory` at `64M` (burst headroom without over-reserving). Shared manifest, so this applies to all spectrum clusters — stops the flapping on mainnet and is preventative on testnet/stage.

```diff
       limits:
-        memory: 64M
+        memory: 256M
```