### PR TITLE
fix(observability): resolve kube-ovn dashboard datasource references

### DIFF
--- a/flux/apps/kube-system/kube-ovn/observability/dashboard.yml
+++ b/flux/apps/kube-system/kube-ovn/observability/dashboard.yml
@@ -1,3 +1,11 @@
+# Upstream kube-ovn dashboards declare a `DS_PROMETHEUS` input and a `datasource`
+# template variable hardcoded to the value "prometheus". This cluster's
+# Prometheus-compatible datasource is "VictoriaMetrics" (uid victoria-metrics),
+# so both references are unresolved out of the box and every panel errors with
+# "Datasource ... was not found". Two-part fix:
+#   1. spec.datasources below maps the ${DS_PROMETHEUS} input -> VictoriaMetrics.
+#   2. A `prometheus`-uid GrafanaDatasource alias (datasource-prometheus-alias.yml)
+#      satisfies the hardcoded `$datasource` template variable.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -8,6 +16,9 @@ spec:
       dashboards: "grafana"
   folder: Kube-OVN
   allowCrossNamespaceImport: true
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "VictoriaMetrics"
   url: "https://raw.githubusercontent.com/kubeovn/kube-ovn/refs/heads/release-1.14/dist/monitoring/cni-grafana.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -20,6 +31,9 @@ spec:
       dashboards: "grafana"
   folder: Kube-OVN
   allowCrossNamespaceImport: true
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "VictoriaMetrics"
   url: "https://raw.githubusercontent.com/kubeovn/kube-ovn/refs/heads/release-1.14/dist/monitoring/controller-grafana.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -32,6 +46,9 @@ spec:
       dashboards: "grafana"
   folder: Kube-OVN
   allowCrossNamespaceImport: true
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "VictoriaMetrics"
   url: "https://raw.githubusercontent.com/kubeovn/kube-ovn/refs/heads/release-1.14/dist/monitoring/ovn-grafana.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -44,6 +61,9 @@ spec:
       dashboards: "grafana"
   folder: Kube-OVN
   allowCrossNamespaceImport: true
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "VictoriaMetrics"
   url: "https://raw.githubusercontent.com/kubeovn/kube-ovn/refs/heads/release-1.14/dist/monitoring/pinger-grafana.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -56,4 +76,7 @@ spec:
       dashboards: "grafana"
   folder: Kube-OVN
   allowCrossNamespaceImport: true
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "VictoriaMetrics"
   url: "https://raw.githubusercontent.com/kubeovn/kube-ovn/refs/heads/release-1.14/dist/monitoring/ovs-grafana.json"

--- a/flux/apps/kube-system/kube-ovn/observability/datasource-prometheus-alias.yml
+++ b/flux/apps/kube-system/kube-ovn/observability/datasource-prometheus-alias.yml
@@ -1,0 +1,25 @@
+# Alias datasource that exists solely to satisfy the kube-ovn dashboards, whose
+# `datasource` template variable is hardcoded to the value "prometheus" (see
+# dashboard.yml). It points at the same VictoriaMetrics backend (vmsingle) and
+# is NOT default, so it does not affect dashboards that resolve the default
+# datasource. Without it the `$datasource`-bound panels error with
+# "Datasource prometheus was not found".
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: prometheus-alias
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  allowCrossNamespaceImport: true
+  datasource:
+    name: prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://vmsingle-stack.observability.svc:8429
+    isDefault: false
+    jsonData:
+      prometheusType: Prometheus
+      timeInterval: 15s

--- a/flux/apps/kube-system/kube-ovn/observability/kustomization.yml
+++ b/flux/apps/kube-system/kube-ovn/observability/kustomization.yml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - dashboard.yml
+  - datasource-prometheus-alias.yml
   - service-monitor.yml
   - alerts.yml


### PR DESCRIPTION
## Problem
Every panel on the Kube-OVN Grafana dashboards (Controller / CNI / OVN / OVS / Pinger) shows `Datasource ... was not found`.

## Root cause
The upstream kube-ovn dashboards (`dist/monitoring/*-grafana.json`, release-1.14) reference their datasource two ways, neither of which resolves in this cluster:
1. A `DS_PROMETHEUS` dashboard input (`${DS_PROMETHEUS}` references in panels/targets).
2. A `datasource` template variable hardcoded to the value `prometheus`.

This cluster's Prometheus-compatible datasource is **VictoriaMetrics** (uid `victoria-metrics`, `isDefault: true`); there is no datasource named/uid `prometheus`. The dashboards that work (dotdc k8s-views, node-exporter) leave the datasource variable empty, so Grafana falls back to the default — kube-ovn hardcodes `prometheus`, so it errors.

## Fix (two parts)
- **`dashboard.yml`** — add `spec.datasources` mapping `DS_PROMETHEUS → VictoriaMetrics` to all 5 `GrafanaDashboard` CRs. Resolves the `${DS_PROMETHEUS}` references (the bulk of panels; 9/11 on CNI, 12+ on Pinger).
- **`datasource-prometheus-alias.yml`** (new) — a `GrafanaDatasource` with uid/name `prometheus` pointing at the same `vmsingle-stack` backend, `isDefault: false`, `allowCrossNamespaceImport: true`. Satisfies the hardcoded `$datasource` template variable. Non-default, so it does not affect dashboards that resolve the default datasource.

## Verification
- `kubectl kustomize flux/apps/kube-system/kube-ovn/observability/` builds clean.
- **Part 1 verified live** on a mainnet cluster: after applying `spec.datasources`, unresolved `${DS_PROMETHEUS}` references dropped to 0 and now point at VictoriaMetrics; all kube-ovn panel queries return data through the VictoriaMetrics proxy.
- Part 2 (alias) was intentionally **not** applied directly to prod (GitOps); the mechanism mirrors the already-working dashboards — a valid datasource reference resolves.

## Deploy note
Reaches the target environment via the per-env tag move (Flux tag > branch).