### PR TITLE
chore(crd-operator): bump vm-api to 0.3.0, unpin on stage

### DIFF
--- a/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/mainnet/release.yml
@@ -29,6 +29,6 @@ spec:
     vmApi:
       image:
         repository: "docker.fluence.dev/crd-vm-api"
-        tag: "0.2.0"
+        tag: "0.3.0"
       jwt:
         jwksUrl: "https://api.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/stage/release.yml
@@ -18,8 +18,5 @@ spec:
         storageClassName: lvm-thin-r1
 
     vmApi:
-      image:
-        repository: "docker.fluence.dev/crd-vm-api"
-        tag: "0.2.0"
       jwt:
         jwksUrl: "https://api.stage.fluence.dev/v1/internal/.well_known/jwks.json"

--- a/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
+++ b/flux/apps/fluence/crd-operator/app/overlays/testnet/release.yml
@@ -29,6 +29,6 @@ spec:
     vmApi:
       image:
         repository: "docker.fluence.dev/crd-vm-api"
-        tag: "0.2.0"
+        tag: "0.3.0"
       jwt:
         jwksUrl: "https://api.testnet.fluence.dev/v1/internal/.well_known/jwks.json"


### PR DESCRIPTION
Bumps the pinned `crd-vm-api` image to `0.3.0` (released 2026-06-17) on testnet and mainnet.

Drops the `vmApi.image` override on the stage overlay so stage tracks the image built from the `spectrum-stage` chart branch (the GitRepository source) instead of a fixed tag — the JWT/jwksUrl config stays.